### PR TITLE
frs downloader

### DIFF
--- a/src/01_downloaders/download_frs.R
+++ b/src/01_downloaders/download_frs.R
@@ -1,6 +1,5 @@
 # download FRS centroids --------------------------------------------------
 
-library(tidyverse)
 library(here)
 
 # Allow for longer timeout to map download file
@@ -10,9 +9,8 @@ options(timeout = 10000)
 frs_url <- paste0("https://edg.epa.gov/data/public/OEI/FRS/",
                  "FRS_Interests_Download.zip")
 
-
 # create dir to store file, download, and un-zip
 fs::dir_create(here("data/frs"))
 download.file(frs_url, here("data/frs/frs.zip"))
 unzip(here("data/frs/frs.zip"), exdir = here("data/frs"))
-cat("Downloaded FRS data.\n")
+cat("Downloaded and unzipped FRS data.\n")


### PR DESCRIPTION
I decided to download from https://www.epa.gov/frs/geospatial-data-download-service "Geospatial information for all publicly available FRS facilities that have latitude/longitude data" -- which updates weekly. A quick comparison of this dataset and the combined csv for states indicates this geodatabase is easier to filter based on the `INTEREST_TYPE`. 


Closes #3 