### PR TITLE
Rs/misc tweaks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-ipykernel
-numpy
-pandas
-python-dotenv
-openpyxl
+numpy==1.22.2
+pandas==1.4.1
+python-dotenv==0.19.2
+openpyxl==3.0.9
+
+# Optional
+ipykernel==6.9.0


### PR DESCRIPTION
This is just a little change to simplify things. "pip freeze" explicitly lists all the dependencies, whereas this list only includes the parent-level packages, making it a bit easier to read and manage.