### PR TITLE
cleaning up and simplifying geometries to geojson

### DIFF
--- a/src/transformers/transform_wsb_labeled.R
+++ b/src/transformers/transform_wsb_labeled.R
@@ -1,4 +1,4 @@
-# transform labeled water system data to standard model
+# transform labeled water system data to standard model -------------------
 
 library(fs)
 library(sf)
@@ -30,7 +30,7 @@ d <- d %>%
   bind_rows() %>% 
   mutate(
     st_areashape   = st_area(geometry),
-    centroid       = st_geometry(st_centroid(geometry))),
+    centroid       = st_geometry(st_centroid(geometry)),
     centroid_x     = st_coordinates(centroid)[, 1],
     centroid_y     = st_coordinates(centroid)[, 2],
     convex_hull    = st_geometry(st_convex_hull(geometry)),


### PR DESCRIPTION
Addressing a few issues:

- Converting centroids to centroid_x, centroid_y (corresponding to longitude, latitude per convention) and dropping convex_hull geometry
- Adding area geometry 
- Adding in names from OK to "gis_name" which unfortunately across that column, is not always consistent with `pws_name` but we will join on `pwsid` with `water_system` so it should be fine
- Removed unnecessary columns
- Calculated the geometries within mutate on the data frame, because they were not being kept when we rbind from list to dataframe
- Filled out data column "source" to indicate where data is from

Question:
- `centroid_x     = unlist(map(centroid, 1))` works really cleanly, but it appears that this step is truncating potentially useful decimal points from the actual centroid lat/longs; do you have an idea of how to prevent this? if not I can jump back in  🙏 