### PR TITLE
transform ucmr zip codes + centroids

### DIFF
--- a/src/transformers/transform_ucmr.R
+++ b/src/transformers/transform_ucmr.R
@@ -39,6 +39,8 @@ cat("Detected", nrow(zip_rm), "nonsense zipcodes:\n"); print(zip_rm)
 # remove nonsense zipcodes
 ucmr <- anti_join(ucmr, zip_rm)
 
+cat("Removed", nrow(zip_rm), "nonsense zipcodes from ucrm data.\n")
+
 
 # merge zip codes to spatial zip code polygon -----------------------------
 


### PR DESCRIPTION
I've added this transformer, which brings together `pwsid` and `zipcode` from UCMR3 and UCMR4 data. I bring in zip code areas, calculate centroids, and then output the pwsid->zipcode geometry lookup as a geojson.

My sense is this will likely be systems that have good data already, but it's worth pulling in case.

Closes #27 