### PR TITLE
fixing imposter anti-join with echo data

### DIFF
--- a/src/transformers/transform_echo_2.R
+++ b/src/transformers/transform_echo_2.R
@@ -1,3 +1,4 @@
+# TODO: translate transform_echo.py into R for one contained script
 
 library(fs)
 library(sf)
@@ -14,33 +15,42 @@ epsg         <- as.numeric(Sys.getenv("WSB_EPSG"))
 # read in transformed echo csv
 echo_file <- path(staging_path, "echo.csv")
 echo <- read_csv(echo_file)
+
+# change reported facility state colname to work with f_drop_imposters()
+echo <- echo %>% mutate(state = fac_state)
                 
 # render lat/long as point geometry, first dropping missing lat/long
 # unfortunately sf does not permit point formation with null coordinates
-# so we'll need to add the rest of the data in later
-echo_sp <- echo %>%
-  # move this step to python transformer
-  mutate(state = fac_state) %>%
+# so we will add the rest of the data (without coordinates) back in later.
+# Create a spatial (sp) version of the echo table.
+echo_sp <- echo  %>%
   filter(!is.na(fac_long) & !is.na(fac_lat)) %>%
-  st_as_sf(., coords = c("fac_long","fac_lat"), crs = epsg)
+  st_as_sf(coords = c("fac_long","fac_lat"), crs = epsg)
 
-# clean invalid geometries. First, create path for invalid geom log file.
+# clean imposters. First, create path for invalid geom log file.
 path_log <- here::here("log", paste0(Sys.Date(), "-imposter-echo.csv"))
 
-# drop invalid geometries and sink a log file for review at the path above.
-echo_sp_imp <- f_drop_imposters(echo_sp, path_log)
+# drop imposters, sink a log file for review at the path above,
+# and keep only relevant columns for the join back to echo tabular data
+echo_sp_valid <- f_drop_imposters(echo_sp, path_log) %>% 
+  select(registry_id, pwsid, geometry)
 
-# collect imposters 
+# collect imposters
 imposters <- echo_sp %>%
-  filter(!(registry_id %in% echo_sp_imp$registry_id))
+  filter(!registry_id %in% echo_sp_valid$registry_id)
 
-# drop imposters from full dataset and join valid geoms
+# registry ids of imposter geometries
+ids_imposters <- unique(imposters$registry_id)
+
+# starting with the full, tabular echo dataset:drop imposters, 
+# join to valid geoms, and concert back into a spatial object
 echo <- echo %>%
   # remove imposters
-  filter(!(registry_id %in% imposters$registry_id)) %>%
-  # join spatially valid geometries to filtered echo dataset
-  left_join(echo_sp_imp %>% select(registry_id, pwsid, geometry), 
-            on = c("registry_id", "pwsid"))
+  filter(!registry_id %in% ids_imposters) %>% 
+  # join spatially valid geometries (non-imposters)
+  left_join(echo_sp_valid, by = c("registry_id", "pwsid")) %>%
+  # convert back to spatial object before saving
+  st_as_sf(crs = epsg)
 
 # write clean echo data to geojson
 path_out <- path(staging_path, "echo.geojson")


### PR DESCRIPTION
@richpauloo thanks for catching my error 
this script:
- subsets data with lat/long to create spatial points (it's annoying that sf doesn't support null geometries in creation, but we can work around this with a join)
- drops imposters
- gets list of imposters, and filters these from the full echo dataset
- joins filtered echo dataset with valid geometries df
- saves to geojson