### PR TITLE
Transformer: NJ

### DIFF
--- a/src/transformers/states/transform_wsb_nj.R
+++ b/src/transformers/states/transform_wsb_nj.R
@@ -31,15 +31,17 @@ nj_wsb <- nj_wsb %>%
     state          = "NJ",
     # importantly, area calculations occur in area weighted epsg
     st_areashape   = st_area(geometry),
-    centroid       = st_geometry(st_centroid(geometry)),
-    centroid_x     = st_coordinates(centroid)[, 1],
-    centroid_y     = st_coordinates(centroid)[, 2],
     convex_hull    = st_geometry(st_convex_hull(geometry)),
     area_hull      = st_area(convex_hull),
     radius         = sqrt(area_hull/pi)
   ) %>%
   # transform back to standard epsg for geojson write
   st_transform(epsg) %>%
+  mutate(
+    centroid       = st_geometry(st_centroid(geometry)),
+    centroid_long  = st_coordinates(centroid)[, 1],
+    centroid_lat   = st_coordinates(centroid)[, 2],
+  ) %>%
   # select columns and rename for staging
   select(
     # data source columns
@@ -52,8 +54,8 @@ nj_wsb <- nj_wsb %>%
     #    owner,
     # geospatial columns
     st_areashape,
-    centroid_x,
-    centroid_y,
+    centroid_long,
+    centroid_lat,
     area_hull,
     radius,
     geometry


### PR DESCRIPTION
[metadata](https://www.arcgis.com/sharing/rest/content/items/00e7ff046ddb4302abe7b49b2ddee07e/info/metadata/metadata.xml?format=default&output=html)

|staging             |raw|
|-----|-----|
| pwsid | PWID |
| pws_name | SYS_NAME |
| state | "NJ" |
| county | |
| city | |
| owner | |

Plus geospatial columns: st_areashape, centroid_x, centroid_y, area_hull, radius, geometry

Comments:
- Both the raw and staging data have 589 rows
- county code is first 2 digits of PWID