### PR TITLE
Transformer: CA

### DIFF
--- a/src/transformers/states/transform_wsb_ca.R
+++ b/src/transformers/states/transform_wsb_ca.R
@@ -14,8 +14,9 @@ epsg         <- as.numeric(Sys.getenv("WSB_EPSG"))
 epsg_aw      <- Sys.getenv("WSB_EPSG_AW")
 
 # Read layer for CA water service boundaries, clean, transform CRS
-ca_wsb <- st_read(dsn = path(data_path, "boundary/ca/SABL_Public_220207/",
-                                         "SABL_Public_220207.shp")) %>% 
+ca_wsb <- st_read(
+  dsn = path(data_path, "boundary/ca/SABL_Public_220207/", 
+             "SABL_Public_220207.shp")) %>% 
   # clean whitespace
   f_clean_whitespace_nas() %>%
   # transform to area weighted CRS


### PR DESCRIPTION
|staging             |raw|
|-----|-----|
| pws_id | WATER_SYST |
| pws_name | WATER_SY_1 |
| state | "CA" |
| county | COUNTY |
| city | |
| owner | |

Plus geospatial columns: st_areashape, centroid_x, centroid_y, area_hull, radius, geometry

Comments:
- Both the raw and staging data have 4941 rows
- There are two ID columns, SABL_PWSID and WATER_SYST, and their values are identical
- ADDRESS_CI is a city column, but I haven't included it because it's not clear which city it refers to -- from the water source, the water system, or something administrative. For example, there are 102 rows where ADDRESS_CI == "SALINAS", which seems outsized for water systems in a small area.