### PR TITLE
Transformer: TX

### DIFF
--- a/src/transformers/states/transform_wsb_tx.R
+++ b/src/transformers/states/transform_wsb_tx.R
@@ -32,15 +32,18 @@ tx_wsb <- tx_wsb %>%
     state          = "TX",
     # importantly, area calculations occur in area weighted epsg
     st_areashape   = st_area(geometry),
-    centroid       = st_geometry(st_centroid(geometry)),
-    centroid_x     = st_coordinates(centroid)[, 1],
-    centroid_y     = st_coordinates(centroid)[, 2],
     convex_hull    = st_geometry(st_convex_hull(geometry)),
     area_hull      = st_area(convex_hull),
     radius         = sqrt(area_hull/pi)
   ) %>%
   # transform back to standard epsg for geojson write
   st_transform(epsg) %>%
+  # compute centroids
+  mutate(
+    centroid       = st_geometry(st_centroid(geometry)),
+    centroid_long  = st_coordinates(centroid)[, 1],
+    centroid_lat   = st_coordinates(centroid)[, 2],
+  ) %>%
   # select columns and rename for staging
   select(
     # data source columns
@@ -53,8 +56,8 @@ tx_wsb <- tx_wsb %>%
     #    owner,
     # geospatial columns
     st_areashape,
-    centroid_x,
-    centroid_y,
+    centroid_long,
+    centroid_lat,
     area_hull,
     radius,
     geometry


### PR DESCRIPTION
find metadata in [manual data download](https://www3.twdb.texas.gov/apps/waterserviceboundaries)

|staging             |raw|
|-----|-----|
| pwsid | PWSId |
| pws_name | pwsName |
| state | "TX" |
| county | |
| city | |
| owner | |

Plus geospatial columns: st_areashape, centroid_x, centroid_y, area_hull, radius, geometry

Comments:
- Both the raw and staging data have 4572 rows