### PR TITLE
Transformer: KS

### DIFF
--- a/src/transformers/states/transform_wsb_ks.R
+++ b/src/transformers/states/transform_wsb_ks.R
@@ -31,15 +31,18 @@ ks_wsb <- ks_wsb %>%
     state          = "KS",
     # importantly, area calculations occur in area weighted epsg
     st_areashape   = st_area(geometry),
-    centroid       = st_geometry(st_centroid(geometry)),
-    centroid_x     = st_coordinates(centroid)[, 1],
-    centroid_y     = st_coordinates(centroid)[, 2],
     convex_hull    = st_geometry(st_convex_hull(geometry)),
     area_hull      = st_area(convex_hull),
     radius         = sqrt(area_hull/pi)
   ) %>%
   # transform back to standard epsg for geojson write
   st_transform(epsg) %>%
+  # compute centroids
+  mutate(
+    centroid       = st_geometry(st_centroid(geometry)),
+    centroid_long  = st_coordinates(centroid)[, 1],
+    centroid_lat   = st_coordinates(centroid)[, 2],
+  ) %>%
   # select columns and rename for staging
   select(
     # data source columns
@@ -52,8 +55,8 @@ ks_wsb <- ks_wsb %>%
     #    owner,
     # geospatial columns
     st_areashape,
-    centroid_x,
-    centroid_y,
+    centroid_long,
+    centroid_lat,
     area_hull,
     radius,
     geometry


### PR DESCRIPTION
no metadata found

|staging | raw |
|-----|-----|
| pwsid | PWSId |
| pws_name | pwsName |
| state | "KS" |
| county | |  
| city | |
| owner | |

Plus geospatial columns: st_areashape, centroid_x, centroid_y, area_hull, radius, geometry

Comments:
- Both the raw and staging data have 801 rows
- There are three name columns: NAME, NAMEWCPSTA, and NAME_SANDP. They're only superficially different, and I chose to keep NAMEWCPSTA because it's the most explicit of the three (examples in order: "Butler Co. RWD # 02" (with no space between # and 02; github inserts a reference without the space), "Butler County RWD No. 02", "Butler RWD 02").