### PR TITLE
Transformer: CT

### DIFF
--- a/src/transformers/states/transform_wsb_ct.R
+++ b/src/transformers/states/transform_wsb_ct.R
@@ -32,15 +32,18 @@ ct_wsb <- ct_wsb %>%
     state          = "CT",
     # importantly, area calculations occur in area weighted epsg
     st_areashape   = st_area(geometry),
-    centroid       = st_geometry(st_centroid(geometry)),
-    centroid_x     = st_coordinates(centroid)[, 1],
-    centroid_y     = st_coordinates(centroid)[, 2],
     convex_hull    = st_geometry(st_convex_hull(geometry)),
     area_hull      = st_area(convex_hull),
     radius         = sqrt(area_hull/pi)
   ) %>%
   # transform back to standard epsg for geojson write
   st_transform(epsg) %>%
+  # compute centroids
+  mutate(
+    centroid       = st_geometry(st_centroid(geometry)),
+    centroid_long  = st_coordinates(centroid)[, 1],
+    centroid_lat   = st_coordinates(centroid)[, 2],
+  ) %>%
   # select columns and rename for staging
   select(
     # data source columns
@@ -53,8 +56,8 @@ ct_wsb <- ct_wsb %>%
     #    owner,
     # geospatial columns
     st_areashape,
-    centroid_x,
-    centroid_y,
+    centroid_long,
+    centroid_lat,
     area_hull,
     radius,
     geometry


### PR DESCRIPTION
no metadata found

|staging | raw |
|-----|-----|
| pwsid | pwsid |
| pws_name | pws_name |
| state | "CT" |
| county | |
| city | |
| owner | |

Plus geospatial columns: st_areashape, centroid_x, centroid_y, area_hull, radius, geometry

Comments:
- Both the raw and staging data have 531 rows