### PR TITLE
Transformer: WA

### DIFF
--- a/src/transformers/states/transform_wsb_wa.R
+++ b/src/transformers/states/transform_wsb_wa.R
@@ -17,6 +17,8 @@ epsg_aw      <- Sys.getenv("WSB_EPSG_AW")
 wa_wsb <- st_read(path(data_path, "boundary/wa/wa.geojson")) %>% 
   # clean whitespace
   f_clean_whitespace_nas() %>%
+  # filter for five-character pwsid's
+  filter(str_detect(WS_ID, "^.{5}$")) %>%
   # transform to area weighted CRS
   st_transform(epsg_aw) %>%
   # correct invalid geometries
@@ -29,6 +31,7 @@ wa_wsb <- wa_wsb %>%
   bind_rows() %>%
   mutate(
     state          = "WA",
+    WS_ID          = paste0("WA53", WS_ID),
     # importantly, area calculations occur in area weighted epsg
     st_areashape   = st_area(geometry),
     convex_hull    = st_geometry(st_convex_hull(geometry)),


### PR DESCRIPTION
no metadata found with original data source
new potential [data source](https://data-f2977-wa-geoservices.opendata.arcgis.com/datasets/WADOH::drinking-water-service-areas/) and [metadata](https://www.arcgis.com/sharing/rest/content/items/b09475f47a5a46ca90fe6a168fb22e6d/info/metadata/metadata.xml?format=default&output=html)

|staging | raw |
|-----|-----|
| pwsid | WS_ID |
| pws_name | WS_Name |
| state | "WA" |
| county | County |
| city | |
| owner | |

Plus geospatial columns: st_areashape, centroid, area_hull, radius, geometry

Comments:
- The raw data has 3909 rows, and the staging data has 3823 rows
- I cleaned IDs by filtering for five-character IDs and appending "WA53" to the front. Most IDs have only five characters/digits, and 80 IDs take other forms (tribal names ("Stillaguamish"), codes like "B387" that are primarily four characters long). Out of those remaining IDs, there are seven IDs of four-character codes that are contained in the ends of SDWIS IDs. However, for those seven rows in the WSB data, only the ID and geometry columns have values; all others, including name, are null.