### PR TITLE
Delete area_hull from schema

### DIFF
--- a/src/transformers/states/transform_wsb_az.R
+++ b/src/transformers/states/transform_wsb_az.R
@@ -59,7 +59,6 @@ az_wsb <- az_wsb %>%
     st_areashape,
     centroid_long,
     centroid_lat,
-    area_hull,
     radius,
     geometry
   )

--- a/src/transformers/states/transform_wsb_ca.R
+++ b/src/transformers/states/transform_wsb_ca.R
@@ -61,7 +61,6 @@ ca_wsb <- ca_wsb %>%
     st_areashape,
     centroid_long,
     centroid_lat,
-    area_hull,
     radius,
     geometry
   )

--- a/src/transformers/states/transform_wsb_ct.R
+++ b/src/transformers/states/transform_wsb_ct.R
@@ -60,7 +60,6 @@ ct_wsb <- ct_wsb %>%
     st_areashape,
     centroid_long,
     centroid_lat,
-    area_hull,
     radius,
     geometry
   )

--- a/src/transformers/states/transform_wsb_ks.R
+++ b/src/transformers/states/transform_wsb_ks.R
@@ -59,7 +59,6 @@ ks_wsb <- ks_wsb %>%
     st_areashape,
     centroid_long,
     centroid_lat,
-    area_hull,
     radius,
     geometry
   )

--- a/src/transformers/states/transform_wsb_mo.R
+++ b/src/transformers/states/transform_wsb_mo.R
@@ -61,7 +61,6 @@ mo_wsb <- mo_wsb %>%
     st_areashape,
     centroid_long,
     centroid_lat,
-    area_hull,
     radius,
     geometry
   )

--- a/src/transformers/states/transform_wsb_nc.R
+++ b/src/transformers/states/transform_wsb_nc.R
@@ -60,7 +60,6 @@ nc_wsb <- nc_wsb %>%
     st_areashape,
     centroid_long,
     centroid_lat,
-    area_hull,
     radius,
     geometry
   )

--- a/src/transformers/states/transform_wsb_nj.R
+++ b/src/transformers/states/transform_wsb_nj.R
@@ -58,7 +58,6 @@ nj_wsb <- nj_wsb %>%
     st_areashape,
     centroid_long,
     centroid_lat,
-    area_hull,
     radius,
     geometry
   )

--- a/src/transformers/states/transform_wsb_nm.R
+++ b/src/transformers/states/transform_wsb_nm.R
@@ -65,7 +65,6 @@ nm_wsb <- nm_wsb %>%
     st_areashape,
     centroid_long,
     centroid_lat,
-    area_hull,
     radius,
     geometry
   )

--- a/src/transformers/states/transform_wsb_ok.R
+++ b/src/transformers/states/transform_wsb_ok.R
@@ -59,7 +59,6 @@ ok_wsb <- ok_wsb %>%
     st_areashape,
     centroid_long,
     centroid_lat,
-    area_hull,
     radius,
     geometry
   )

--- a/src/transformers/states/transform_wsb_pa.R
+++ b/src/transformers/states/transform_wsb_pa.R
@@ -59,7 +59,6 @@ pa_wsb <- pa_wsb %>%
     st_areashape,
     centroid_long,
     centroid_lat,
-    area_hull,
     radius,
     geometry
   )

--- a/src/transformers/states/transform_wsb_tx.R
+++ b/src/transformers/states/transform_wsb_tx.R
@@ -60,7 +60,6 @@ tx_wsb <- tx_wsb %>%
     st_areashape,
     centroid_long,
     centroid_lat,
-    area_hull,
     radius,
     geometry
   )

--- a/src/transformers/states/transform_wsb_wa.R
+++ b/src/transformers/states/transform_wsb_wa.R
@@ -62,7 +62,6 @@ wa_wsb <- wa_wsb %>%
     st_areashape,
     centroid_long,
     centroid_lat,
-    area_hull,
     radius,
     geometry
   )


### PR DESCRIPTION
From Rich: "We can remove area_hull from all wsb. It fundamentally serves the purpose of calculating a radius which we use as an outcome variable to train models on."