### PR TITLE
UCMR: deduplicate on pwsid, combine geometries

### DIFF
--- a/src/transformers/transform_ucmr.R
+++ b/src/transformers/transform_ucmr.R
@@ -60,7 +60,7 @@ zipcodes <- zipcode_areas %>%
     st_areashape   = st_area(geometry),
     convex_hull    = st_geometry(st_convex_hull(geometry)),
     area_hull      = st_area(convex_hull)
-  ) 
+  ) %>% 
   select(all_of(cols_keep))
 
 


### PR DESCRIPTION
Reuses wsb code to combine rows with duplicate pwsid's, combining their geometries and recalculating radius, area, and centroid.

This reduces UCMR data row count from 24,180 to 7069 rows (by 70%), and there are 2998 groups of rows with duplicate pwsids. In the largest group, for example, there are 955 rows with the pwsid "CA1910067"; see that data subset mapped in the image below.

<img width="363" alt="Screen Shot 2022-03-29 at 10 00 23 PM" src="https://user-images.githubusercontent.com/87207557/160754657-314be565-ff90-4cd4-a5ff-a844e3f2bbd2.png">

Linked issue #104 