### PR TITLE
Remove pattern matching hyphen + digits; replace apostrophe

### DIFF
--- a/src/transformers/transform_sdwis_geo_areas.py
+++ b/src/transformers/transform_sdwis_geo_areas.py
@@ -63,8 +63,9 @@ geo_area["city_served"] = geo_area["city_served"].str.replace("\.?-\.?\s*\d{4}",
 # Replace "&apos;" with "'"
 geo_area["city_served"] = geo_area["city_served"].str.replace("&apos;", 
                                                               "'", regex=True)
-# Replace parenthetical with letter in it, e.g. (V) or (T)
-geo_area["city_served"] = geo_area["city_served"].str.replace("\([A-Z]\)", 
+                                                              
+# Replace parenthetical with single letter (plus any spaces) in it, e.g. (V) or (T)
+geo_area["city_served"] = geo_area["city_served"].str.replace("\(\s*[A-Z]\s*\)", 
                                                               "", regex=True)
                                                               
 # Replace excess whitespace within line with a single space


### PR DESCRIPTION
Remove `-` followed by 0 or 1 `.`, 0 or more spaces, and four digits. Also remove `.` immediately following city title abbreviation.

Examples of `city_served` values, before and after the added code:
| Before      | After |
| ----------- | ----------- |
| `LYNDHURST TWP-0232,LOWER TWP.-0505`  | `LYNDHURST TWP,LOWER TWP`   |
| `EAST BRUNSWICK TWP.-1204,MILLTOWN BORO-1212,NORTH BRUNSWICK TWP.-1215`    | `EAST BRUNSWICK TWP,MILLTOWN BORO,NORTH BRUNSWICK TWP`       |
| `OLDMANS TWP.-1706,PENNS GROVE BORO-   1707,CARNEY&apos;S POINT TWP.-1713`   | `OLDMANS TWP,PENNS GROVE BORO,CARNEY'S POINT TWP`        |
| `WEYMOUTH TWP-.0123`	 | `WEYMOUTH TWP`   |

I specified four digits because of this one value, `AZ JCT 64  US-180`, where `180` is valid.

@jess-goddard Is my substitution for the apostrophe ok? Update 3/30/22: Keep the substitution for now to recreate the intention of the original data. Note that the data in the output of transform_tigris_ne.R does not strictly follow either convention; sometimes there is no apostrophe, or there is an extra space around the apostrophe.

Also, the data includes values with both `TWP` and `TWP.` (abbreviation with and without a period). I left this as is, but if it's helpful for matching down the line, I can remove the period for consistency. Update 3/30/22: Removed the period

Linked issue #103