### PR TITLE
restoring state column to transformers

### DIFF
--- a/src/functions/f_drop_imposters.R
+++ b/src/functions/f_drop_imposters.R
@@ -20,7 +20,7 @@ f_drop_imposters <- function(d, path_log){
   if(!dir_exists(here::here("log"))) dir_create(here::here("log"))
   
   # reported state name 
-  d = rename(d, state_reported = state)
+  d = mutate(d, state_reported = state)
   
   # create state name to abbreviation key with built-in R objects
   key = tibble(name = state.name, state_intersection = state.abb)


### PR DESCRIPTION
@richpauloo the function `f_drop_imposters()` was using `rename()` to the state column, and then later dropping that column when keeping the valid geometries. I have switched it to `mutate()` so that we don't lose the state column, which impacts the matching steps downstream.